### PR TITLE
always use empty string for missing values in query

### DIFF
--- a/lib/Net/Azure/EventHubs.pm
+++ b/lib/Net/Azure/EventHubs.pm
@@ -49,6 +49,10 @@ sub new {
 sub _uri {
     my ($self, $path, %params) = @_;
     $path ||= '/';
+    for my $value (values %params) {
+        $value = ''
+            if !defined $value;
+    }
     my $uri = URI->new($self->authorizer->endpoint);
     $uri->scheme('https');
     $uri->path($path);


### PR DESCRIPTION
Explicitly use an empty string as the value for query parameters, since that is what we want to be generated.

Fixes failures with URI 5.19.